### PR TITLE
Add numpy to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM anapsix/alpine-java:jdk7
 MAINTAINER esnunes
 
-RUN apk add --no-cache curl tar ;\
-  curl -s http://d3kbcqa49mib13.cloudfront.net/spark-1.6.2-bin-hadoop2.6.tgz | tar -xz -C /usr/local ;\
-  cd /usr/local && ln -s spark-1.6.2-bin-hadoop2.6 spark ;\
+RUN apk add --no-cache curl tar &&\
+  curl -s http://d3kbcqa49mib13.cloudfront.net/spark-1.6.2-bin-hadoop2.6.tgz | tar -xz -C /usr/local &&\
+  cd /usr/local && ln -s spark-1.6.2-bin-hadoop2.6 spark &&\
   apk add --no-cache procps
 
-RUN apk add --update python python-dev gfortran py-pip build-base ;\
-  pip install cython ;\
-  ln -s /usr/include/locale.h /usr/include/xlocale.h ;\
+RUN apk add --update python python-dev gfortran py-pip build-base &&\
+  pip install cython &&\
+  ln -s /usr/include/locale.h /usr/include/xlocale.h &&\
   pip install numpy
 
 ENV SPARK_HOME /usr/local/spark

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ RUN apk add --no-cache curl tar ;\
   cd /usr/local && ln -s spark-1.6.2-bin-hadoop2.6 spark ;\
   apk add --no-cache procps
 
+RUN apk add --update python python-dev gfortran py-pip build-base ;\
+  pip install cython ;\
+  ln -s /usr/include/locale.h /usr/include/xlocale.h ;\
+  pip install numpy
+
 ENV SPARK_HOME /usr/local/spark
 ENV PATH $PATH:$SPARK_HOME/bin
 


### PR DESCRIPTION
Install `numpy` in the image because the module `pyspark.ml.Pipeline` requires it.
